### PR TITLE
Pass identifier as context and error as param since raven can handle it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cauliflower",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A simple error handler",
   "main": "dist/index.js",
   "scripts": {

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -3,8 +3,8 @@ import Raven from 'raven-js';
 var sentry = {
   name: 'sentry',
   catch: (name, e) => {
-    sentry.setExtraContext(e);
-    Raven.captureException(name);
+    sentry.setExtraContext(name);
+    Raven.captureException(e);
   },
   setDSN: (dsn) => {
     Raven.config(dsn).install();


### PR DESCRIPTION
Based on this, we should return the full object instead of the string for `captureException`. Context receive the identifier.
https://docs.sentry.io/clients/javascript/usage/#raven-js-reporting-errors